### PR TITLE
Suppress "warning: XXX has a LOAD segment with RWX permissions" message

### DIFF
--- a/rp2040/make/Makefile
+++ b/rp2040/make/Makefile
@@ -27,6 +27,7 @@ LDFLAGS += -mcpu=cortex-m0plus -mthumb
 LDFLAGS += -nostartfiles
 LDFLAGS += -Wl,--gc-sections
 LDFLAGS += -Wl,--script=../linker/rp2040.ld
+LDFLAGS += -Wl,--no-warn-rwx-segments
 
 INCLUDES += \
   -I../include \


### PR DESCRIPTION
See https://github.com/raspberrypi/pico-sdk/issues/1029#issuecomment-1261743841